### PR TITLE
Android Channel Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+Update the Android SDK references to include channel support
+
 ## 1.0.0
 
 Initial release of Kumulos SDK for Flutter, including all features:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add the following dependency to your `pubspec.yaml` and run `pub install`:
 
 ```yaml
 dependencies:
-  kumulos_sdk_flutter: 1.0.0
+  kumulos_sdk_flutter: 1.1.0
 ```
 
 Next, create a `kumulos.json` file in your project's root directory with Kumulos configuration:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,6 @@ android {
 }
 
 dependencies {
-    debugApi 'com.kumulos.android:kumulos-android-debug:12.0.0'
-    releaseApi 'com.kumulos.android:kumulos-android-release:12.0.0'
+    debugApi 'com.kumulos.android:kumulos-android-debug:12.1.0'
+    releaseApi 'com.kumulos.android:kumulos-android-release:12.1.0'
 }

--- a/android/src/main/java/com/kumulos/flutter/kumulos_sdk_flutter/KumulosInitProvider.java
+++ b/android/src/main/java/com/kumulos/flutter/kumulos_sdk_flutter/KumulosInitProvider.java
@@ -35,7 +35,7 @@ import io.flutter.plugin.common.EventChannel;
 public class KumulosInitProvider extends ContentProvider {
     private static final String TAG = KumulosInitProvider.class.getName();
 
-    private static final String SDK_VERSION = "1.0.0";
+    private static final String SDK_VERSION = "1.1.0";
     private static final int RUNTIME_TYPE = 9;
     private static final int SDK_TYPE = 11;
 

--- a/ios/Classes/KumulosSdkFlutterPlugin.m
+++ b/ios/Classes/KumulosSdkFlutterPlugin.m
@@ -2,7 +2,7 @@
 #import <KumulosSDK/KumulosSDK.h>
 @import CoreLocation;
 
-static const NSString* KSFlutterSdkVersion = @"1.0.0";
+static const NSString* KSFlutterSdkVersion = @"1.1.0";
 
 #pragma mark - Event bridge helper
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kumulos_sdk_flutter
-description: Official SDK for integrating Kumulos services with your Flutter projects 
-version: 1.0.0
+description: Official SDK for integrating Kumulos services with your Flutter projects
+version: 1.1.0
 homepage: https://github.com/Kumulos/KumulosSdkFlutter
 
 environment:


### PR DESCRIPTION
### Description of Changes

The Kumulos push API now supports the mutually exclusive keys for android notifications

- notificationType: Hint to the SDK whether a notification should default to the tray or a banner (priority default or max respectively), this is automatic and handled between the Kumulos push pipeline and the SDK.

- notificationChannel: If the app developer has setup specific channels for content then setting this key will forward it to the end consumer and is readable on the PushMessage object.

### Breaking Changes

-   None

### Release Checklist

Prepare:

-   [x] Detail any breaking changes. Breaking changes require a new major version number
-   [ ] Check the example app builds and runs as expected
-   [x] Add an entry in `CHANGELOG.md`

Bump versions in:

-   [x] `pubspec.yaml`
-   [x] `ios/Classes/KumulosSdkFlutterPlugin.m`
-   [x] `android/src/main/java/com/kumulos/flutter/kumulos_sdk_flutter/KumulosInitProvider.java`
-   [x] `README.md`

Release:

-   [ ] Squash and merge to master
-   [ ] Delete branch once merged
-   [ ] Create tag from master matching chosen version
-   [ ] Run `dart pub publish --dry-run` to check what will be published
-   [ ] Run `dart pub publish` to upload to https://pub.dev
